### PR TITLE
add possibility to chain and return multiple operations from data source

### DIFF
--- a/RobinHood.podspec
+++ b/RobinHood.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RobinHood'
-  s.version          = '2.4.2'
+  s.version          = '2.5.0'
   s.summary          = 'Takes data from "rich" remote source and caches them in originaly "poor" local storage to speed up user interface.'
 
   s.description      = <<-DESC

--- a/RobinHood/Classes/DataProvider/DataProvider/AnyDataProvider.swift
+++ b/RobinHood/Classes/DataProvider/DataProvider/AnyDataProvider.swift
@@ -12,8 +12,8 @@ import Foundation
 public final class AnyDataProvider<T: Identifiable & Equatable>: DataProviderProtocol {
     public typealias Model = T
 
-    private let _fetchById: (String, ((Result<T?, Error>?) -> Void)?) -> BaseOperation<T?>
-    private let _fetchPage: (UInt, ((Result<[T], Error>?) -> Void)?) -> BaseOperation<[T]>
+    private let _fetchById: (String, ((Result<T?, Error>?) -> Void)?) -> CompoundOperationWrapper<T?>
+    private let _fetchPage: (UInt, ((Result<[T], Error>?) -> Void)?) -> CompoundOperationWrapper<[T]>
 
     private let _addObserver: (AnyObject, DispatchQueue?,
     @escaping ([DataProviderChange<T>]) -> Void, @escaping (Error) -> Void, DataProviderObserverOptions) -> Void
@@ -40,11 +40,13 @@ public final class AnyDataProvider<T: Identifiable & Equatable>: DataProviderPro
         self.executionQueue = dataProvider.executionQueue
     }
 
-    public func fetch(by modelId: String, completionBlock: ((Result<T?, Error>?) -> Void)?) -> BaseOperation<T?> {
+    public func fetch(by modelId: String,
+                      completionBlock: ((Result<T?, Error>?) -> Void)?) -> CompoundOperationWrapper<T?> {
         return _fetchById(modelId, completionBlock)
     }
 
-    public func fetch(page index: UInt, completionBlock: ((Result<[T], Error>?) -> Void)?) -> BaseOperation<[T]> {
+    public func fetch(page index: UInt,
+                      completionBlock: ((Result<[T], Error>?) -> Void)?) -> CompoundOperationWrapper<[T]> {
         return _fetchPage(index, completionBlock)
     }
 

--- a/RobinHood/Classes/DataProvider/DataProvider/AnyDataProviderSource.swift
+++ b/RobinHood/Classes/DataProvider/DataProvider/AnyDataProviderSource.swift
@@ -14,8 +14,8 @@ import Foundation
 public final class AnyDataProviderSource<T: Identifiable>: DataProviderSourceProtocol {
     public typealias Model = T
 
-    private let _fetchById: (String) -> BaseOperation<Model?>
-    private let _fetchByPage: (UInt) -> BaseOperation<[Model]>
+    private let _fetchById: (String) -> CompoundOperationWrapper<Model?>
+    private let _fetchByPage: (UInt) -> CompoundOperationWrapper<[Model]>
 
     /**
      *  Initializes type erasure object with implementation of source protocol.
@@ -39,17 +39,17 @@ public final class AnyDataProviderSource<T: Identifiable>: DataProviderSourcePro
      *    - fetchById: Closure to return object by id.
      */
 
-    public init(fetchByPage: @escaping (UInt) -> BaseOperation<[Model]>,
-                fetchById: @escaping (String) -> BaseOperation<Model?>) {
+    public init(fetchByPage: @escaping (UInt) -> CompoundOperationWrapper<[Model]>,
+                fetchById: @escaping (String) -> CompoundOperationWrapper<Model?>) {
         _fetchByPage = fetchByPage
         _fetchById = fetchById
     }
 
-    public func fetchOperation(by modelId: String) -> BaseOperation<T?> {
+    public func fetchOperation(by modelId: String) -> CompoundOperationWrapper<T?> {
         return _fetchById(modelId)
     }
 
-    public func fetchOperation(page index: UInt) -> BaseOperation<[T]> {
+    public func fetchOperation(page index: UInt) -> CompoundOperationWrapper<[T]> {
         return _fetchByPage(index)
     }
 }

--- a/RobinHood/Classes/DataProvider/DataProvider/DataProvider+Protocol.swift
+++ b/RobinHood/Classes/DataProvider/DataProvider/DataProvider+Protocol.swift
@@ -85,7 +85,7 @@ extension DataProvider: DataProviderProtocol {
             throw BaseOperationError.parentOperationCancelled
         }
 
-        reduceOperation.addDependency(sourceCancellationOperation)
+        reduceOperation.addDependency(sourceWrapper.targetOperation)
 
         reduceOperation.completionBlock = {
             completionBlock?(reduceOperation.result)
@@ -140,7 +140,7 @@ extension DataProvider: DataProviderProtocol {
             }
 
             let reduceOperation = ClosureOperation<[T]> {
-                if let result = try repositoryOperation.extractResultData() {
+                if let result = try sourceCancellationOperation.extractResultData(), result.count > 0 {
                     return result
                 }
 

--- a/RobinHood/Classes/DataProvider/DataProvider/DataProvider.swift
+++ b/RobinHood/Classes/DataProvider/DataProvider/DataProvider.swift
@@ -97,11 +97,11 @@ extension DataProvider {
             return
         }
 
-        let sourceOperation = source.fetchOperation(page: 0)
+        let sourceWrapper = source.fetchOperation(page: 0)
 
         let repositoryOperation = repository.fetchAllOperation()
 
-        let differenceOperation = createDifferenceOperation(dependingOn: sourceOperation,
+        let differenceOperation = createDifferenceOperation(dependingOn: sourceWrapper.targetOperation,
                                                             repositoryOperation: repositoryOperation)
 
         let saveOperation = createSaveRepositoryOperation(dependingOn: differenceOperation)
@@ -132,13 +132,13 @@ extension DataProvider {
         repositoryUpdateOperation = saveOperation
 
         if let syncOperation = lastSyncOperation, !syncOperation.isFinished {
-            sourceOperation.addDependency(syncOperation)
+            sourceWrapper.allOperations.forEach { $0.addDependency(syncOperation) }
             repositoryOperation.addDependency(syncOperation)
         }
 
         lastSyncOperation = saveOperation
 
-        let operations = [sourceOperation, repositoryOperation, differenceOperation, saveOperation]
+        let operations = sourceWrapper.allOperations + [repositoryOperation, differenceOperation, saveOperation]
 
         executionQueue.addOperations(operations, waitUntilFinished: false)
     }

--- a/RobinHood/Classes/DataProvider/DataProvider/DataProviderProtocols.swift
+++ b/RobinHood/Classes/DataProvider/DataProvider/DataProviderProtocols.swift
@@ -36,11 +36,13 @@ public protocol DataProviderProtocol {
      *  - parameters:
      *    - modelId: Identifier of the object to fetch.
      *    - completionBlock: Block to call on completion. `Result` value is passed as a parameter.
-     *  - returns: Operation object to cancel if there is a need or to chain with other operations.
-     *  **Don't try** to override operation's completion block but provide completion block to the function instead.
+     *  - returns: Operations object wrapper to cancel if there is a need or to chain with other operations.
+     *  **Don't try** to override target operation's completion block but provide completion
+     *  block to the function instead.
      */
 
-    func fetch(by modelId: String, completionBlock: ((Result<Model?, Error>?) -> Void)?) -> BaseOperation<Model?>
+    func fetch(by modelId: String,
+               completionBlock: ((Result<Model?, Error>?) -> Void)?) -> CompoundOperationWrapper<Model?>
 
     /**
      *  Returns a concrete page of objects from local store or fetches from remote store in case it is absent locally.
@@ -54,11 +56,13 @@ public protocol DataProviderProtocol {
      *  - parameters:
      *    - page: `UInt` index of the page.
      *    - completionBlock: Block to call on completion. `Result` value is passed as a parameter.
-     *  - returns: Operation object to cancel if there is a need or to chain with other operations.
-     *  **Don't try** to override operation's completion block but provide completion block to the function instead.
+     *  - returns: Operations object wrapper to cancel if there is a need or to chain with other operations.
+     *  **Don't try** to override target operation's completion block but provide completion
+     *  block to the function instead.
      */
 
-    func fetch(page index: UInt, completionBlock: ((Result<[Model], Error>?) -> Void)?) -> BaseOperation<[Model]>
+    func fetch(page index: UInt,
+               completionBlock: ((Result<[Model], Error>?) -> Void)?) -> CompoundOperationWrapper<[Model]>
 
     /**
      *  Adds observer to notify when there are changes in local storage.
@@ -161,11 +165,11 @@ public protocol DataProviderSourceProtocol {
      *  - parameters:
      *    - modelId: String that unique identifies the object to fetch;
      *
-     *  - returns: Operation object to cancel if needed or chain with other
-     *  operations.
+     *  - returns: Operation object wrapper to cancel if there is needed or to
+     *   chain with other operations.
      */
 
-    func fetchOperation(by modelId: String) -> BaseOperation<Model?>
+    func fetchOperation(by modelId: String) -> CompoundOperationWrapper<Model?>
 
     /**
      *  Fetches a page of objects from remote source.
@@ -176,8 +180,8 @@ public protocol DataProviderSourceProtocol {
      *  - parameters:
      *    - page: `UInt` index of the page.
      *
-     *  - returns: Operation object to cancel if needed or chain with other
-     *  operations.
+     *  - returns: Operation object wrapper to cancel if there is needed or to
+     *   chain with other operations.
      */
-    func fetchOperation(page index: UInt) -> BaseOperation<[Model]>
+    func fetchOperation(page index: UInt) -> CompoundOperationWrapper<[Model]>
 }

--- a/RobinHood/Classes/DataProvider/SingleValueProvider/AnySingleValueProviderSource.swift
+++ b/RobinHood/Classes/DataProvider/SingleValueProvider/AnySingleValueProviderSource.swift
@@ -14,7 +14,7 @@ import Foundation
 public final class AnySingleValueProviderSource<T>: SingleValueProviderSourceProtocol {
     public typealias Model = T
 
-    private let _fetch: () -> BaseOperation<Model?>
+    private let _fetch: () -> CompoundOperationWrapper<Model?>
 
     /**
      *  Initializes type erasure object with implementation of single value provider source protocol.
@@ -27,11 +27,11 @@ public final class AnySingleValueProviderSource<T>: SingleValueProviderSourcePro
         _fetch = source.fetchOperation
     }
 
-    public init(fetch: @escaping () -> BaseOperation<Model?>) {
+    public init(fetch: @escaping () -> CompoundOperationWrapper<Model?>) {
         _fetch = fetch
     }
 
-    public func fetchOperation() -> BaseOperation<Model?> {
+    public func fetchOperation() -> CompoundOperationWrapper<Model?> {
         return _fetch()
     }
 }

--- a/RobinHood/Classes/DataProvider/SingleValueProvider/SingleValueProvider.swift
+++ b/RobinHood/Classes/DataProvider/SingleValueProvider/SingleValueProvider.swift
@@ -121,11 +121,11 @@ extension SingleValueProvider {
             return
         }
 
-        let sourceOperation = source.fetchOperation()
+        let sourceWrapper = source.fetchOperation()
 
         let repositoryOperation = repository.fetchOperation(by: targetIdentifier)
 
-        let differenceOperation = createDifferenceOperation(dependingOn: sourceOperation,
+        let differenceOperation = createDifferenceOperation(dependingOn: sourceWrapper.targetOperation,
                                                             repositoryOperation: repositoryOperation)
 
         let saveOperation = createSaveRepositoryOperation(dependingOn: differenceOperation)
@@ -156,13 +156,13 @@ extension SingleValueProvider {
         repositoryUpdateOperation = saveOperation
 
         if let syncOperation = lastSyncOperation, !syncOperation.isFinished {
-            sourceOperation.addDependency(syncOperation)
+            sourceWrapper.allOperations.forEach { $0.addDependency(syncOperation) }
             repositoryOperation.addDependency(syncOperation)
         }
 
         lastSyncOperation = saveOperation
 
-        let operations = [sourceOperation, repositoryOperation, differenceOperation, saveOperation]
+        let operations = sourceWrapper.allOperations + [repositoryOperation, differenceOperation, saveOperation]
 
         executionQueue.addOperations(operations, waitUntilFinished: false)
     }

--- a/RobinHood/Classes/DataProvider/SingleValueProvider/SingleValueProviderProtocols.swift
+++ b/RobinHood/Classes/DataProvider/SingleValueProvider/SingleValueProviderProtocols.swift
@@ -34,11 +34,12 @@ public protocol SingleValueProviderProtocol {
      *
      *  - parameters:
      *    - completionBlock: Block to call on completion. `Result` value is passed as a parameter.
-     *  - returns: Operation object to cancel if there is a need or to chain with other operations.
-     *  **Don't try** to override operation's completion block but provide completion block to the function instead.
+     *  - returns: Operation object wrapper to cancel if there is a need or to chain with other operations.
+     *  **Don't try** to override target operation's completion block but provide completion
+     *  block to the function instead.
      */
 
-    func fetch(with completionBlock: ((Result<Model?, Error>?) -> Void)?) -> BaseOperation<Model?>
+    func fetch(with completionBlock: ((Result<Model?, Error>?) -> Void)?) -> CompoundOperationWrapper<Model?>
 
     /**
      *  Adds observer to notify when there are changes in local storage.
@@ -137,9 +138,9 @@ public protocol SingleValueProviderSourceProtocol {
     /**
      *  Fetches then object from remote source.
      *
-     *  - returns: Operation object to cancel if needed or chain with other
+     *  - returns: Operation wrapper object to cancel if needed or chain with other
      *  operations.
      */
 
-    func fetchOperation() -> BaseOperation<Model?>
+    func fetchOperation() -> CompoundOperationWrapper<Model?>
 }

--- a/RobinHood/Classes/DataProvider/StreamableProvider/StreamableProvider.swift
+++ b/RobinHood/Classes/DataProvider/StreamableProvider/StreamableProvider.swift
@@ -162,7 +162,8 @@ extension StreamableProvider: StreamableProviderProtocol {
     public func fetch(offset: Int,
                       count: Int,
                       synchronized: Bool,
-                      with completionBlock: @escaping (Result<[Model], Error>?) -> Void) -> BaseOperation<[Model]> {
+                      with completionBlock: @escaping (Result<[Model], Error>?) -> Void)
+        -> CompoundOperationWrapper<[Model]> {
         let sliceRequest = RepositorySliceRequest(offset: offset, count: count, reversed: false)
         let operation = repository.fetchOperation(by: sliceRequest)
 
@@ -189,7 +190,7 @@ extension StreamableProvider: StreamableProviderProtocol {
             operationManager.enqueue(operations: [operation], in: .transient)
         }
 
-        return operation
+        return CompoundOperationWrapper(targetOperation: operation)
     }
 
     public func addObserver(_ observer: AnyObject,

--- a/RobinHood/Classes/DataProvider/StreamableProvider/StreamableProviderProtocols.swift
+++ b/RobinHood/Classes/DataProvider/StreamableProvider/StreamableProviderProtocols.swift
@@ -35,14 +35,15 @@ public protocol StreamableProviderProtocol {
      *    - completionBlock: Block to call on completion. `Result` value is passed as a parameter.
      *    Note that remote objects may not be delivered in the completion closure and the client needs to add
      *    an observer to receive remained part of the list.
-     *  - returns: Operation object to cancel if there is a need or to chain with other operations.
-     *  **Don't try** to override operation's completion block but provide completion block to the function instead.
+     *  - returns: Operation wrapper object to cancel if there is a need or to chain with other operations.
+     *  **Don't try** to override target operation's completion block but provide completion
+     *  block to the function instead.
      */
 
     func fetch(offset: Int,
                count: Int,
                synchronized: Bool,
-               with completionBlock: @escaping (Result<[Model], Error>?) -> Void) -> BaseOperation<[Model]>
+               with completionBlock: @escaping (Result<[Model], Error>?) -> Void) -> CompoundOperationWrapper<[Model]>
 
     /**
      *  Adds observer to notify when there are changes in local storage.

--- a/RobinHood/Classes/Operations/CancellableCall.swift
+++ b/RobinHood/Classes/Operations/CancellableCall.swift
@@ -1,0 +1,21 @@
+/**
+* Copyright Soramitsu Co., Ltd. All Rights Reserved.
+* SPDX-License-Identifier: GPL-3.0
+*/
+
+import Foundation
+
+/**
+ *  Abstract protocol designed to provide identity and cancellation support
+ *  for asynchronious work.
+ *
+ *  Use the protocol to return from methods that schedules cancellable work.
+ */
+
+public protocol CancellableCall: class {
+    /**
+     *  Cancels all operations related to call
+     */
+
+    func cancel()
+}

--- a/RobinHood/Classes/Operations/CompoundOperationWrapper.swift
+++ b/RobinHood/Classes/Operations/CompoundOperationWrapper.swift
@@ -11,7 +11,7 @@ import Foundation
  *  it depends on.
  */
 
-public struct CompoundOperationWrapper<ResultType> {
+public class CompoundOperationWrapper<ResultType> {
 
     /**
      *  Returns a list which consists of dependencies and target operation.
@@ -37,11 +37,9 @@ public struct CompoundOperationWrapper<ResultType> {
         self.targetOperation = targetOperation
         self.dependencies = dependencies
     }
+}
 
-    /**
-     *  Cancels all operations.
-     */
-
+extension CompoundOperationWrapper: CancellableCall {
     public func cancel() {
         allOperations.forEach { $0.cancel() }
     }

--- a/Tests/DataProvider/DataProvider/DataProviderBaseTests.swift
+++ b/Tests/DataProvider/DataProvider/DataProviderBaseTests.swift
@@ -11,24 +11,24 @@ class DataProviderBaseTests: XCTestCase {
     func fetchById<T>(_ identifier: String, from dataProvider: DataProvider<T>) -> Result<T?, Error>? {
         let expectation = XCTestExpectation()
 
-        let fetchByIdOperation = dataProvider.fetch(by: identifier) { _ in
+        let fetchByIdWrapper = dataProvider.fetch(by: identifier) { _ in
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationDuration)
 
-        return fetchByIdOperation.result
+        return fetchByIdWrapper.targetOperation.result
     }
 
     func fetch<T>(page: UInt, from dataProvider: DataProvider<T>) -> Result<[T], Error>? {
         let expectation = XCTestExpectation()
 
-        let fetchByPageOperation = dataProvider.fetch(page: page) { _ in
+        let fetchByPageWrapper = dataProvider.fetch(page: page) { _ in
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationDuration)
 
-        return fetchByPageOperation.result
+        return fetchByPageWrapper.targetOperation.result
     }
 }

--- a/Tests/DataProvider/SingleDataProvider/SingleValueProviderBaseTests.swift
+++ b/Tests/DataProvider/SingleDataProvider/SingleValueProviderBaseTests.swift
@@ -10,12 +10,12 @@ class SingleValueProviderBaseTests: XCTestCase {
     func fetch<T>(from dataProvider: SingleValueProvider<T>) -> Result<T?, Error>? {
         let expectation = XCTestExpectation()
 
-        let fetchOperation = dataProvider.fetch { _ in
+        let fetchWrapper = dataProvider.fetch { _ in
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationDuration)
 
-        return fetchOperation.result
+        return fetchWrapper.targetOperation.result
     }
 }


### PR DESCRIPTION
Currently, there can be only a single operation created by data source to fetch data. However sometimes it required to fetch and merge data from different sources and it is convient to separate the task into multiple subtasks with a common goal but due to the restriction that data source can return only a single operation for request of data provider it is not possible to break a big task into subtasks.